### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/stefuhnee/budget-buddy.png?label=ready&title=Ready)](https://waffle.io/stefuhnee/budget-buddy)
 # budget-buddy
 Team Cannoli: Stefanie, Vic, Dan, Jeff
 Code Fellows seattle-201d3


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/stefuhnee/budget-buddy

This was requested by a real person (user stefuhnee) on waffle.io, we're not trying to spam you.
